### PR TITLE
Support sync strategy

### DIFF
--- a/lib/snowagent.rb
+++ b/lib/snowagent.rb
@@ -4,6 +4,7 @@ require 'logger'
 
 require "snowagent/version"
 require "snowagent/agent"
+require "snowagent/async_strategy"
 require "snowagent/sender"
 require "snowagent/configuration"
 

--- a/lib/snowagent.rb
+++ b/lib/snowagent.rb
@@ -5,7 +5,9 @@ require 'logger'
 require "snowagent/version"
 require "snowagent/agent"
 require "snowagent/async_strategy"
+require "snowagent/sync_strategy"
 require "snowagent/sender"
+require "snowagent/service"
 require "snowagent/configuration"
 
 module SnowAgent

--- a/lib/snowagent/agent.rb
+++ b/lib/snowagent/agent.rb
@@ -1,20 +1,13 @@
 module SnowAgent
   class Agent
     def initialize(configuration)
-      @queue = Queue.new
-
-      run_sender(configuration)
-    end
-
-    def run_sender(conf)
-      sender_thread = Thread.new { Sender.new(@queue, conf).run }
-      sender_thread.abort_on_exception = true
+      @strategy = AsyncStrategy.new(configuration)
     end
 
     Metric = Struct.new(:name, :value, :at)
 
     def metric(key, value, time = Time.now.to_i)
-      @queue.push(Metric.new(key, value, time))
+      @strategy.metric(Metric.new(key, value, time))
     end
   end
 end

--- a/lib/snowagent/agent.rb
+++ b/lib/snowagent/agent.rb
@@ -1,7 +1,8 @@
 module SnowAgent
   class Agent
     def initialize(configuration)
-      @strategy = AsyncStrategy.new(configuration)
+      strategy_class = configuration.async ? AsyncStrategy : SyncStrategy
+      @strategy      = strategy_class.new(configuration)
     end
 
     Metric = Struct.new(:name, :value, :at)

--- a/lib/snowagent/async_strategy.rb
+++ b/lib/snowagent/async_strategy.rb
@@ -1,0 +1,17 @@
+module SnowAgent
+  class AsyncStrategy
+    def initialize(configuration)
+      @queue = Queue.new
+      run_sender(configuration)
+    end
+
+    def run_sender(conf)
+      sender_thread = Thread.new { Sender.new(@queue, conf).run }
+      sender_thread.abort_on_exception = true
+    end
+
+    def metric(metric)
+      @queue.push(metric)
+    end
+  end
+end

--- a/lib/snowagent/configuration.rb
+++ b/lib/snowagent/configuration.rb
@@ -15,6 +15,9 @@ module SnowAgent
     # Timout when opening connection to the server
     attr_accessor :open_timeout
 
+    # Whether send metrics asynchronously or not
+    attr_accessor :async
+
     def initialize
       self.server        = ENV['SNOWMANIO_SERVER']
       self.secret_token  = ENV['SNOWMANIO_SECRET_TOKEN']
@@ -22,6 +25,8 @@ module SnowAgent
 
       self.read_timeout = 1
       self.open_timeout = 1
+
+      self.async        = true
     end
 
     # Determines if the agent confiured to send metrics.

--- a/lib/snowagent/sender.rb
+++ b/lib/snowagent/sender.rb
@@ -1,8 +1,8 @@
 module SnowAgent
   class Sender
     def initialize(queue, conf)
-      @report_uri = URI.join(conf.server, "agent/metrics")
       @queue      = queue
+      @service    = Service.new(conf)
       @conf       = conf
       @metrics    = []
       @send_at    = Time.now.to_i + @conf.send_interval
@@ -27,28 +27,11 @@ module SnowAgent
     end
 
     def send_data
-      payload = JSON.dump({ metrics: @metrics.map(&:to_h) })
-
       # TODO:
       # * requeue data on failure
-      post_data(payload)
+      @service.post_data({ metrics: @metrics.map(&:to_h) })
 
       @metrics.clear
-    end
-
-    # TODO: use faraday instead of raw net/http?
-    def post_data(payload)
-      http = Net::HTTP.new(@report_uri.host, @report_uri.port)
-
-      http.use_ssl      = (@report_uri.scheme == "https")
-      http.read_timeout = @conf.read_timeout if @conf.read_timeout
-      http.open_timeout = @conf.open_timeout if @conf.open_timeout
-
-      req = Net::HTTP::Post.new("#{@report_uri.path}?#{@report_uri.query}")
-      req.body =  payload
-
-      response = http.request(req)
-      response
     end
   end
 end

--- a/lib/snowagent/service.rb
+++ b/lib/snowagent/service.rb
@@ -1,0 +1,30 @@
+module SnowAgent
+  # Encapsulates HTTP related logic for sending data
+  # to SnowmanIO instance
+  # TODO: use faraday instead of raw net/http?
+  class Service
+    def initialize(conf)
+      @uri        =  URI.join(conf.server, "agent/metrics")
+      @connection = build_connection(conf)
+    end
+
+    def post_data(payload)
+      req = Net::HTTP::Post.new("#{@uri.path}?#{@uri.query}")
+      req.body =  JSON.dump(payload)
+
+      response = @connection.request(req)
+
+      response
+    end
+
+    def build_connection(conf)
+      http = Net::HTTP.new(@uri.host, @uri.port)
+
+      http.use_ssl      = (@uri.scheme == "https")
+      http.read_timeout = conf.read_timeout if conf.read_timeout
+      http.open_timeout = conf.open_timeout if conf.open_timeout
+
+      http
+    end
+  end
+end

--- a/lib/snowagent/sync_strategy.rb
+++ b/lib/snowagent/sync_strategy.rb
@@ -1,0 +1,11 @@
+module SnowAgent
+  class SyncStrategy
+    def initialize(configuration)
+      @service = Service.new(configuration)
+    end
+
+    def metric(metric)
+      @service.post_data({ metrics: [metric.to_h]})
+    end
+  end
+end


### PR DESCRIPTION
So users will be able to choose whether to send it sync or async
```ruby
SnowAgent.configure do |config|
   config.async = false
end

SnowAgent.metric("name", 1)
```